### PR TITLE
object to slackObject: Object (capital O)

### DIFF
--- a/src/feedback.service.ts
+++ b/src/feedback.service.ts
@@ -10,7 +10,7 @@ import 'rxjs/add/observable/of';
 export class FeedbackService {
   constructor(private http: Http, @Inject(SlackUrlToken) private slackUrlToken) {}
 
-  notifySlack(slackObject: object) {
+  notifySlack(slackObject: Object) {
 
     const header = new Headers();
     header.append('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');


### PR DESCRIPTION
Got an error `cannot find name 'object'`. Changed object to Object and it works.